### PR TITLE
Fix Sample for VSO and fix the documentation build.

### DIFF
--- a/sunpy/net/jsoc/attrs.py
+++ b/sunpy/net/jsoc/attrs.py
@@ -1,18 +1,29 @@
 from __future__ import absolute_import
 
+__all__ = ['Series', 'Protocol', 'Notify', 'Compression', 'Wavelength', 'Time',
+           'Segment', 'Sample']
+
 import astropy.units as u
 
-from sunpy.net.attr import (Attr, AttrWalker, AttrAnd, AttrOr)
-from sunpy.net.vso.attrs import Time,Sample,_VSOSimpleAttr
+from sunpy.net.attr import Attr, AttrWalker, AttrAnd, AttrOr
+from sunpy.net.vso.attrs import _VSOSimpleAttr
+from sunpy.net.vso.attrs import Time as vTime, Sample as vSample
 
-__all__ = ['Series', 'Protocol', 'Notify', 'Compression', 'Wavelength', 'Time',
-           'Segment','Sample']
+###############################################################################
+# This is a horrific hack to make automodapi pick up these as jsoc attrs.
 
 
-class Time(Time):
-    """
-    Time range to download
-    """
+class Time(vTime):
+    __doc__ = vTime.__doc__
+    pass
+
+
+class Sample(vSample):
+    __doc__ = vSample.__doc__
+    pass
+
+###############################################################################
+
 
 class Series(_VSOSimpleAttr):
     """
@@ -48,7 +59,8 @@ class Notify(_VSOSimpleAttr):
     def __init__(self, value):
         super(Notify, self).__init__(value)
         if value.find('@') == -1:
-            raise ValueError("Notify attribute must contain an '@' symbol to be a valid email address")
+            raise ValueError("Notify attribute must contain an '@' symbol "
+                             "to be a valid email address")
         self.value = value
 
 

--- a/sunpy/net/jsoc/jsoc.py
+++ b/sunpy/net/jsoc/jsoc.py
@@ -479,11 +479,11 @@ class JSOCClient(object):
         # Extract and format segment
         if segment != '':
             segment = '{{{segment}}}'.format(segment=segment)
-        
+
         sample = kwargs.get('sample', '')
         if sample:
-            sample = '@{}s'.format(sample.to(u.s).value)
-        
+            sample = '@{}s'.format(sample)
+
         dataset = '{series}[{start}-{end}{sample}]{wavelength}{segment}'.format(
                    series=series, start=start_time.strftime("%Y.%m.%d_%H:%M:%S_TAI"),
                    end=end_time.strftime("%Y.%m.%d_%H:%M:%S_TAI"),

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -88,6 +88,22 @@ class Wave(Attr, _Range):
 
 
 class Time(Attr, _Range):
+    """
+    Specify the time range of the query.
+
+    Parameters
+    ----------
+
+    start : SunPy Time String or `~sunpy.time.TimeRange`.
+        The start time in a format parseable by `~sunpy.time.parse_time` or
+        a `sunpy.time.TimeRange` object.
+
+    end : SunPy Time String
+        The end time of the range.
+
+    near: SunPy Time String
+
+    """
     def __init__(self, start, end=None, near=None):
         if end is None and not isinstance(start, _TimeRange):
             raise ValueError("Specify start and end or start has to be a TimeRange")

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -102,6 +102,8 @@ class Time(Attr, _Range):
         The end time of the range.
 
     near: SunPy Time String
+    	Return a singular record closest in time to this value as possible, 
+    	inside the start and end window. Note: not all providers support this.
 
     """
     def __init__(self, start, end=None, near=None):

--- a/sunpy/net/vso/attrs.py
+++ b/sunpy/net/vso/attrs.py
@@ -194,11 +194,18 @@ class Filter(_VSOSimpleAttr):
 
 class Sample(_VSOSimpleAttr):
     """
-    Time interval for data sampling
+    Time interval for data sampling.
+
+    Parameters
+    ----------
+
+    value : `astropy.units.Quantity`
+        A sampling rate convertable to seconds.
     """
     @u.quantity_input(value=u.s)
     def __init__(self, value):
         super(Sample,self).__init__(value)
+        self.value = value.to(u.s).value
 
 
 class Quicklook(_VSOSimpleAttr):


### PR DESCRIPTION
Hi,

In the interests of getting this feature into 0.6 I thought I would fix up the documentation for you,, as sphinx can be a bit of a pain.

Also, I moved the quantity -> seconds conversion into the vso.Sample attribute so that vso still gets the Sample.value attribute in seconds like it expects.

If you merge this PR it will update your PR to SunPy.
